### PR TITLE
Allow broken symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.coverage.*
 /.tox
 /htmlcov*
+/.cache

--- a/library/runit_sv.py
+++ b/library/runit_sv.py
@@ -106,9 +106,15 @@ class FileRecord(object):
                 if e.errno != errno.ENOENT:
                     raise
         elif self.content is True:
-            if not os.path.exists(self.path):
-                raise FileDoesNotExistError(self.path)
-            os.chmod(self.path, self.mode)
+            try:
+                filestat = os.lstat(self.path)
+            except OSError as e:
+                if e.errno == errno.ENOENT:
+                    raise FileDoesNotExistError(self.path)
+                else:
+                    raise
+            if not stat.S_ISLNK(filestat.st_mode):
+                os.chmod(self.path, self.mode)
         else:
             makedirs_exist_ok(os.path.dirname(self.path))
             with tempfile.NamedTemporaryFile(delete=False) as outfile:

--- a/library/runit_sv.py
+++ b/library/runit_sv.py
@@ -116,8 +116,11 @@ class FileRecord(object):
             if not stat.S_ISLNK(filestat.st_mode):
                 os.chmod(self.path, self.mode)
         else:
-            makedirs_exist_ok(os.path.dirname(self.path))
-            with tempfile.NamedTemporaryFile(delete=False) as outfile:
+            outdir = os.path.dirname(self.path)
+            makedirs_exist_ok(outdir)
+            outfile = tempfile.NamedTemporaryFile(
+                dir=outdir, prefix='.tmp', suffix='~', delete=False)
+            with outfile:
                 outfile.write(self.content)
             os.chmod(outfile.name, self.mode)
             os.rename(outfile.name, self.path)

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+/ansible-tmp

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+remote_tmp = tests/ansible-tmp

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ deps =
 
 [testenv]
 setenv =
+    ANSIBLE_CONFIG = {toxinidir}/tests/ansible.cfg
     PYTHONPATH = library
 commands =
     pip show ansible


### PR DESCRIPTION
Allow broken symlinks when `content=True`; fix `EXDEV` in some cases.
