### PR TITLE
Specify 'list' type for python list variables

### DIFF
--- a/library/runit_sv.py
+++ b/library/runit_sv.py
@@ -11,7 +11,6 @@ import stat
 import tempfile
 import traceback
 
-
 EXECUTABLE = 0o777
 NONEXECUTABLE = 0o666
 SETTABLE_MASK = 0o7777
@@ -212,9 +211,9 @@ def main(module_cls):
     module = module_cls(
         argument_spec=dict(
             name=dict(required=True),
-            sv_directory=dict(default=['/etc/sv']),
-            service_directory=dict(default=['/service', '/etc/service']),
-            init_d_directory=dict(default=['/etc/init.d']),
+            sv_directory=dict(type='list', default=['/etc/sv']),
+            service_directory=dict(type='list', default=['/service', '/etc/service']),
+            init_d_directory=dict(type='list', default=['/etc/init.d']),
             runscript=dict(required=True),
             log_runscript=dict(),
             supervise_link=dict(),


### PR DESCRIPTION
Beginning with Ansible 2.1, list declarations like

`init_d_directory=dict(default=['/etc/init.d'])`

do not work properly unless the variable is declared with an explicit type. This PR adds the declarations, making ansible-runit-sv work with Ansible 2.1+.

This fix is backtested to work with its previous behavior with Ansible 2.0.2 and 1.9.3.
